### PR TITLE
[Optimize] Accelerate zlib crc32_z with PCLMULQDQ and VPCLMULQDQ on x86_64 platform

### DIFF
--- a/extra/zlib/zlib-1.2.13/CMakeLists.txt
+++ b/extra/zlib/zlib-1.2.13/CMakeLists.txt
@@ -137,6 +137,15 @@ set(ZLIB_SRCS
     zutil.c
 )
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    LIST(APPEND ZLIB_PRIVATE_HDRS arch_x86.h
+                                  crc32_x86.h)
+
+    LIST(APPEND ZLIB_SRCS arch_x86.c
+                          crc32_x86_pclmul.c
+                          crc32_x86_vpclmulqdq.c)
+endif()
+
 if(NOT MINGW)
     set(ZLIB_DLL_SRCS
         win32/zlib1.rc # If present will override custom build rule below.

--- a/extra/zlib/zlib-1.2.13/arch_x86.c
+++ b/extra/zlib/zlib-1.2.13/arch_x86.c
@@ -1,0 +1,94 @@
+/* Copyright (c) 2026, Chengdu Haiguang IC Design Co., Ltd. All rights reserved. */
+
+#include <stdint.h>
+
+static inline uint32_t cpuid_leaf1_ecx(void)
+{
+    uint32_t eax, ebx, ecx, edx;
+
+    eax = 0x01;
+    ecx = 0x00;
+    __asm__ volatile (
+            "cpuid"
+            : "+a"(eax), "=b"(ebx), "+c"(ecx), "=d"(edx)
+            :
+            : "memory"
+    );
+
+    return ecx;
+}
+
+static inline int has_osxsave(void)
+{
+    return (cpuid_leaf1_ecx() >> 27) & 0x01;
+}
+
+// check XCR0 Bits
+static inline uint64_t xgetbv(uint32_t ecx)
+{
+    uint32_t eax, edx;
+    __asm__ volatile (
+            "xgetbv"
+            : "=a"(eax), "=d"(edx)
+            : "c"(ecx)
+            : "memory"
+    );
+
+    return ((uint64_t)edx << 32) | eax;
+}
+
+static inline int xcr0_ymm_enabled(void)
+{
+    uint64_t xcr0 = xgetbv(0);
+
+    // Check XCR0[2:1] == '11'(YMM state enabled)
+    return ((xcr0 >> 1) & 0x03) == 0x03;
+}
+
+static inline int xcr0_zmm_enabled(void) {
+    uint64_t xcr0 = xgetbv(0);
+
+    // Check XCR0[7:5] == '111'(ZMM + OPMASK state enabled)
+    return ((xcr0 >> 5) & 0x07) == 0x07;
+}
+
+/* Runtime check for crc32_z_impl_x86_avx: AVX + OS YMM state + PCLMULQDQ. */
+int has_crc32_x86_avx(void) {
+    uint32_t ecx;
+
+    ecx = cpuid_leaf1_ecx();
+    if (((ecx >> 27) & 0x01) == 0) /* OSXSAVE */
+        return 0;
+    if (((ecx >> 28) & 0x01) == 0) /* AVX */
+        return 0;
+    if (((ecx >> 1) & 0x01) == 0) /* PCLMULQDQ */
+        return 0;
+    if (!xcr0_ymm_enabled())
+        return 0;
+    return 1;
+}
+
+int has_crc32_x86_avx512(void)
+{
+    uint32_t eax, ebx, ecx, edx;
+
+    if (!has_osxsave())
+         return 0;
+    if (!xcr0_ymm_enabled())
+         return 0;
+
+    if (!xcr0_zmm_enabled())
+        return 0;
+
+    eax = 0x07;
+    ecx = 0x00;
+    __asm__ volatile (
+            "cpuid"
+            : "+a"(eax), "=b"(ebx), "+c"(ecx), "=d"(edx)
+            :
+            : "memory"
+    );
+
+    /* AVX512F, AVX512VL, and VPCLMULQDQ required by crc32_z_impl_x86_avx512. */
+    return ((ebx >> 16) & 0x01) && ((ebx >> 31) & 0x01) && ((ecx >> 10) & 0x01);
+}

--- a/extra/zlib/zlib-1.2.13/arch_x86.h
+++ b/extra/zlib/zlib-1.2.13/arch_x86.h
@@ -1,0 +1,24 @@
+/* Copyright (c) 2026, Chengdu Haiguang IC Design Co., Ltd. All rights reserved. */
+
+#include "zutil.h"
+
+#define ZLIB_X86_64_CRC32_PCLMUL 1
+
+/* Check GCC version and only apply vpclmulqdq target attribute when compiler is GCC 8 or later */
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+#  define HAVE_VPCLMULQDQ_ATTRIBUTE 1
+#endif
+
+int has_crc32_x86_avx(void);
+/* Runtime check for crc32_z_impl_x86_avx512: AVX-512 state + AVX512F/VL + VPCLMULQDQ. */
+int has_crc32_x86_avx512(void);
+
+/* SIMD optimized variants of crc32_z */
+unsigned long
+crc32_z_impl_x86_avx(unsigned long crc, const unsigned char FAR* buf,
+    z_size_t len); /* pclmul */
+#ifdef HAVE_VPCLMULQDQ_ATTRIBUTE
+unsigned long
+crc32_z_impl_x86_avx512(unsigned long crc, const unsigned char FAR* buf,
+    z_size_t len); /* vpclmulqdq */
+#endif

--- a/extra/zlib/zlib-1.2.13/crc32.c
+++ b/extra/zlib/zlib-1.2.13/crc32.c
@@ -29,6 +29,10 @@
 
 #include "zutil.h"      /* for Z_U4, Z_U8, z_crc_t, and FAR definitions */
 
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+#include "arch_x86.h"
+#endif
+
  /*
   A CRC of a message is computed on N braids of words in the message, where
   each word consists of W bytes (4 or 8). If N is 3, for example, then three
@@ -149,23 +153,6 @@ local z_word_t byte_swap(word)
 /* CRC polynomial. */
 #define POLY 0xedb88320         /* p(x) reflected, with x^32 implied */
 
-#ifdef DYNAMIC_CRC_TABLE
-
-local z_crc_t FAR crc_table[256];
-local z_crc_t FAR x2n_table[32];
-local void make_crc_table OF((void));
-#ifdef W
-   local z_word_t FAR crc_big_table[256];
-   local z_crc_t FAR crc_braid_table[W][256];
-   local z_word_t FAR crc_braid_big_table[W][256];
-   local void braid OF((z_crc_t [][256], z_word_t [][256], int, int));
-#endif
-#ifdef MAKECRCH
-   local void write_table OF((FILE *, const z_crc_t FAR *, int));
-   local void write_table32hi OF((FILE *, const z_word_t FAR *, int));
-   local void write_table64 OF((FILE *, const z_word_t FAR *, int));
-#endif /* MAKECRCH */
-
 /*
   Define a once() function depending on the availability of atomics. If this is
   compiled with DYNAMIC_CRC_TABLE defined, and if CRCs will be computed in
@@ -250,6 +237,23 @@ local void once(state, init)
 }
 
 #endif
+
+#ifdef DYNAMIC_CRC_TABLE
+
+local z_crc_t FAR crc_table[256];
+local z_crc_t FAR x2n_table[32];
+local void make_crc_table OF((void));
+#ifdef W
+   local z_word_t FAR crc_big_table[256];
+   local z_crc_t FAR crc_braid_table[W][256];
+   local z_word_t FAR crc_braid_big_table[W][256];
+   local void braid OF((z_crc_t [][256], z_word_t [][256], int, int));
+#endif
+#ifdef MAKECRCH
+   local void write_table OF((FILE *, const z_crc_t FAR *, int));
+   local void write_table32hi OF((FILE *, const z_word_t FAR *, int));
+   local void write_table64 OF((FILE *, const z_word_t FAR *, int));
+#endif /* MAKECRCH */
 
 /* State for once(). */
 local once_t made = ONCE_INIT;
@@ -600,6 +604,27 @@ const z_crc_t FAR * ZEXPORT get_crc_table()
     return (const z_crc_t FAR *)crc_table;
 }
 
+#ifdef ZLIB_X86_64_CRC32_PCLMUL
+static unsigned long (*crc32_x86_fp)(unsigned long crc, const unsigned char FAR* buf,
+                                     z_size_t len) = NULL;
+local once_t crc32_x86_once = ONCE_INIT;
+
+static void crc32_x86_init(void) {
+    crc32_x86_fp = NULL;
+#ifdef HAVE_VPCLMULQDQ_ATTRIBUTE
+    if (has_crc32_x86_avx512())
+        crc32_x86_fp = crc32_z_impl_x86_avx512;
+    else
+#endif
+    if (has_crc32_x86_avx())
+        crc32_x86_fp = crc32_z_impl_x86_avx;
+}
+
+static void crc32_x86_setup_native(void) {
+    once(&crc32_x86_once, crc32_x86_init);
+}
+#endif /* ZLIB_X86_64_CRC32_PCLMUL */
+
 /* =========================================================================
  * Use ARM machine instructions if available. This will compute the CRC about
  * ten times faster than the braided calculation. This code does not check for
@@ -752,6 +777,12 @@ unsigned long ZEXPORT crc32_z(crc, buf, len)
 {
     /* Return initial CRC, if requested. */
     if (buf == Z_NULL) return 0;
+
+#ifdef ZLIB_X86_64_CRC32_PCLMUL
+    crc32_x86_setup_native();
+    if (crc32_x86_fp != NULL)
+        return crc32_x86_fp(crc, buf, len);
+#endif
 
 #ifdef DYNAMIC_CRC_TABLE
     once(&made, make_crc_table);

--- a/extra/zlib/zlib-1.2.13/crc32_x86.h
+++ b/extra/zlib/zlib-1.2.13/crc32_x86.h
@@ -1,0 +1,618 @@
+/*
+ * Compute the CRC32 using a parallelized folding approach with the PCLMULQDQ
+ * instruction.
+ *
+ * Copyright (C) 2013 Intel Corporation. All rights reserved.
+ * Copyright (C) 2016 Marian Beermann (support for initial value)
+ * Copyright Wangyang Guo (wangyang.guo@intel.com)
+ * 
+ * Modifications Copyright (C) 2024-2025, Advanced Micro Devices. All rights reserved.
+ *
+ * For conditions of distribution and use, see copyright notice in zlib.h
+ */
+#ifndef _CRC32_X86
+#define _CRC32_X86
+#include "zutil.h"
+#include <stdint.h>
+
+#ifdef CRC_32_Z_VARIANT
+#include "crc32.h" // crc tables
+#include <immintrin.h>
+
+#define ALIGNED_(x) __attribute__ ((aligned(x)))
+
+#define CRC32_FOLD_BUFFER_SIZE (16 * 4) /* sizeof(__m128i) * (4 folds) */
+
+typedef struct crc32_fold_s {
+    uint8_t fold[CRC32_FOLD_BUFFER_SIZE];
+    uint32_t value;
+} crc32_fold;
+
+#define DO1 c = crc_table[(c ^ *buf++) & 0xff] ^ (c >> 8)
+
+static inline uint32_t CRC_32_Z_X86(uint32_t crc32, const uint8_t* buf, size_t len);
+
+#if CRC_32_Z_VARIANT == CRC_32_Z_X86_PCLMUL
+
+#define CRC_32_Z_TARGET_ISA "avx,pclmul"
+unsigned long
+crc32_z_impl_x86_avx(unsigned long crc, const unsigned char FAR* buf,
+    z_size_t len) {
+    return CRC_32_Z_X86(crc, buf, len);
+}
+
+#elif CRC_32_Z_VARIANT == CRC_32_Z_X86_VPCLMULQDQ
+
+#define CRC_32_Z_TARGET_ISA "avx,pclmul,avx512f,vpclmulqdq"
+unsigned long
+crc32_z_impl_x86_avx512(unsigned long crc, const unsigned char FAR* buf,
+    z_size_t len) {
+    return CRC_32_Z_X86(crc, buf, len);
+}
+#define X86_VPCLMULQDQ
+
+#endif /* CRC_32_Z_VARIANT == */
+
+#define ONCE(op)                 if (first) { first = 0; op; }
+#define XOR_INITIAL128(where)    ONCE(where = _mm_xor_si128(where, xmm_initial))
+#ifdef X86_VPCLMULQDQ
+#  define XOR_INITIAL512(where)  ONCE(where = _mm512_xor_si512(where, zmm_initial))
+#endif
+
+#ifdef X86_VPCLMULQDQ
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static size_t fold_16_vpclmulqdq(__m128i * xmm_crc0, __m128i * xmm_crc1,
+    __m128i * xmm_crc2, __m128i * xmm_crc3, const uint8_t * src, size_t len,
+    __m128i init_crc, int32_t first) {
+#if (defined(__clang__) || (defined(__GNUC__) && (__GNUC__ > 11)))
+    __m512i zmm_initial = _mm512_zextsi128_si512(init_crc);
+#else
+    __m512i zmm_initial = _mm512_setzero_si512();
+    zmm_initial = _mm512_castsi128_si512(init_crc);
+#endif
+    __m512i zmm_t0, zmm_t1, zmm_t2, zmm_t3;
+    __m512i zmm_crc0, zmm_crc1, zmm_crc2, zmm_crc3;
+    __m512i z0, z1, z2, z3;
+    size_t len_tmp = len;
+    const __m512i zmm_fold4 = _mm512_set4_epi32(
+        0x00000001, 0x54442bd4, 0x00000001, 0xc6e41596);
+    const __m512i zmm_fold16 = _mm512_set4_epi32(
+        0x00000001, 0x1542778a, 0x00000001, 0x322d1430);
+
+    // zmm register init
+    zmm_crc0 = _mm512_setzero_si512();
+    zmm_t0 = _mm512_loadu_si512((__m512i*)src);
+    XOR_INITIAL512(zmm_t0);
+    zmm_crc1 = _mm512_loadu_si512((__m512i*)src + 1);
+    zmm_crc2 = _mm512_loadu_si512((__m512i*)src + 2);
+    zmm_crc3 = _mm512_loadu_si512((__m512i*)src + 3);
+
+    /* already have intermediate CRC in xmm registers
+        * fold4 with 4 xmm_crc to get zmm_crc0
+    */
+    zmm_crc0 = _mm512_inserti32x4(zmm_crc0, *xmm_crc0, 0);
+    zmm_crc0 = _mm512_inserti32x4(zmm_crc0, *xmm_crc1, 1);
+    zmm_crc0 = _mm512_inserti32x4(zmm_crc0, *xmm_crc2, 2);
+    zmm_crc0 = _mm512_inserti32x4(zmm_crc0, *xmm_crc3, 3);
+    z0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x01);
+    zmm_crc0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x10);
+    zmm_crc0 = _mm512_ternarylogic_epi32(zmm_crc0, z0, zmm_t0, 0x96);
+
+    len -= 256;
+    src += 256;
+
+    // fold-16 loops
+    while (len >= 256) {
+        zmm_t0 = _mm512_loadu_si512((__m512i*)src);
+        zmm_t1 = _mm512_loadu_si512((__m512i*)src + 1);
+        zmm_t2 = _mm512_loadu_si512((__m512i*)src + 2);
+        zmm_t3 = _mm512_loadu_si512((__m512i*)src + 3);
+
+        z0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold16, 0x01);
+        z1 = _mm512_clmulepi64_epi128(zmm_crc1, zmm_fold16, 0x01);
+        z2 = _mm512_clmulepi64_epi128(zmm_crc2, zmm_fold16, 0x01);
+        z3 = _mm512_clmulepi64_epi128(zmm_crc3, zmm_fold16, 0x01);
+
+        zmm_crc0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold16, 0x10);
+        zmm_crc1 = _mm512_clmulepi64_epi128(zmm_crc1, zmm_fold16, 0x10);
+        zmm_crc2 = _mm512_clmulepi64_epi128(zmm_crc2, zmm_fold16, 0x10);
+        zmm_crc3 = _mm512_clmulepi64_epi128(zmm_crc3, zmm_fold16, 0x10);
+
+        zmm_crc0 = _mm512_ternarylogic_epi32(zmm_crc0, z0, zmm_t0, 0x96);
+        zmm_crc1 = _mm512_ternarylogic_epi32(zmm_crc1, z1, zmm_t1, 0x96);
+        zmm_crc2 = _mm512_ternarylogic_epi32(zmm_crc2, z2, zmm_t2, 0x96);
+        zmm_crc3 = _mm512_ternarylogic_epi32(zmm_crc3, z3, zmm_t3, 0x96);
+
+        len -= 256;
+        src += 256;
+    }
+    // zmm_crc[0,1,2,3] -> zmm_crc0
+    z0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x01);
+    zmm_crc0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x10);
+    zmm_crc0 = _mm512_ternarylogic_epi32(zmm_crc0, z0, zmm_crc1, 0x96);
+
+    z0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x01);
+    zmm_crc0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x10);
+    zmm_crc0 = _mm512_ternarylogic_epi32(zmm_crc0, z0, zmm_crc2, 0x96);
+
+    z0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x01);
+    zmm_crc0 = _mm512_clmulepi64_epi128(zmm_crc0, zmm_fold4, 0x10);
+    zmm_crc0 = _mm512_ternarylogic_epi32(zmm_crc0, z0, zmm_crc3, 0x96);
+
+    // zmm_crc0 -> xmm_crc[0, 1, 2, 3]
+    *xmm_crc0 = _mm512_extracti32x4_epi32(zmm_crc0, 0);
+    *xmm_crc1 = _mm512_extracti32x4_epi32(zmm_crc0, 1);
+    *xmm_crc2 = _mm512_extracti32x4_epi32(zmm_crc0, 2);
+    *xmm_crc3 = _mm512_extracti32x4_epi32(zmm_crc0, 3);
+
+    return (len_tmp - len);  // return n bytes processed
+}
+#endif /* X86_VPCLMULQDQ */
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static void fold_1(__m128i * xmm_crc0, __m128i * xmm_crc1, __m128i * xmm_crc2, __m128i * xmm_crc3) {
+    const __m128i xmm_fold4 = _mm_set_epi32(0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596);
+    __m128i x_tmp3;
+    __m128 ps_crc0, ps_crc3, ps_res;
+
+    x_tmp3 = *xmm_crc3;
+
+    *xmm_crc3 = *xmm_crc0;
+    *xmm_crc0 = _mm_clmulepi64_si128(*xmm_crc0, xmm_fold4, 0x01);
+    *xmm_crc3 = _mm_clmulepi64_si128(*xmm_crc3, xmm_fold4, 0x10);
+    ps_crc0 = _mm_castsi128_ps(*xmm_crc0);
+    ps_crc3 = _mm_castsi128_ps(*xmm_crc3);
+    ps_res = _mm_xor_ps(ps_crc0, ps_crc3);
+
+    *xmm_crc0 = *xmm_crc1;
+    *xmm_crc1 = *xmm_crc2;
+    *xmm_crc2 = x_tmp3;
+    *xmm_crc3 = _mm_castps_si128(ps_res);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static void fold_2(__m128i * xmm_crc0, __m128i * xmm_crc1, __m128i * xmm_crc2, __m128i * xmm_crc3) {
+    const __m128i xmm_fold4 = _mm_set_epi32(0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596);
+    __m128i x_tmp3, x_tmp2;
+    __m128 ps_crc0, ps_crc1, ps_crc2, ps_crc3, ps_res31, ps_res20;
+
+    x_tmp3 = *xmm_crc3;
+    x_tmp2 = *xmm_crc2;
+
+    *xmm_crc3 = *xmm_crc1;
+    *xmm_crc1 = _mm_clmulepi64_si128(*xmm_crc1, xmm_fold4, 0x01);
+    *xmm_crc3 = _mm_clmulepi64_si128(*xmm_crc3, xmm_fold4, 0x10);
+    ps_crc3 = _mm_castsi128_ps(*xmm_crc3);
+    ps_crc1 = _mm_castsi128_ps(*xmm_crc1);
+    ps_res31 = _mm_xor_ps(ps_crc3, ps_crc1);
+
+    *xmm_crc2 = *xmm_crc0;
+    *xmm_crc0 = _mm_clmulepi64_si128(*xmm_crc0, xmm_fold4, 0x01);
+    *xmm_crc2 = _mm_clmulepi64_si128(*xmm_crc2, xmm_fold4, 0x10);
+    ps_crc0 = _mm_castsi128_ps(*xmm_crc0);
+    ps_crc2 = _mm_castsi128_ps(*xmm_crc2);
+    ps_res20 = _mm_xor_ps(ps_crc0, ps_crc2);
+
+    *xmm_crc0 = x_tmp2;
+    *xmm_crc1 = x_tmp3;
+    *xmm_crc2 = _mm_castps_si128(ps_res20);
+    *xmm_crc3 = _mm_castps_si128(ps_res31);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static void fold_3(__m128i * xmm_crc0, __m128i * xmm_crc1, __m128i * xmm_crc2, __m128i * xmm_crc3) {
+    const __m128i xmm_fold4 = _mm_set_epi32(0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596);
+    __m128i x_tmp3;
+    __m128 ps_crc0, ps_crc1, ps_crc2, ps_crc3, ps_res32, ps_res21, ps_res10;
+
+    x_tmp3 = *xmm_crc3;
+
+    *xmm_crc3 = *xmm_crc2;
+    *xmm_crc2 = _mm_clmulepi64_si128(*xmm_crc2, xmm_fold4, 0x01);
+    *xmm_crc3 = _mm_clmulepi64_si128(*xmm_crc3, xmm_fold4, 0x10);
+    ps_crc2 = _mm_castsi128_ps(*xmm_crc2);
+    ps_crc3 = _mm_castsi128_ps(*xmm_crc3);
+    ps_res32 = _mm_xor_ps(ps_crc2, ps_crc3);
+
+    *xmm_crc2 = *xmm_crc1;
+    *xmm_crc1 = _mm_clmulepi64_si128(*xmm_crc1, xmm_fold4, 0x01);
+    *xmm_crc2 = _mm_clmulepi64_si128(*xmm_crc2, xmm_fold4, 0x10);
+    ps_crc1 = _mm_castsi128_ps(*xmm_crc1);
+    ps_crc2 = _mm_castsi128_ps(*xmm_crc2);
+    ps_res21 = _mm_xor_ps(ps_crc1, ps_crc2);
+
+    *xmm_crc1 = *xmm_crc0;
+    *xmm_crc0 = _mm_clmulepi64_si128(*xmm_crc0, xmm_fold4, 0x01);
+    *xmm_crc1 = _mm_clmulepi64_si128(*xmm_crc1, xmm_fold4, 0x10);
+    ps_crc0 = _mm_castsi128_ps(*xmm_crc0);
+    ps_crc1 = _mm_castsi128_ps(*xmm_crc1);
+    ps_res10 = _mm_xor_ps(ps_crc0, ps_crc1);
+
+    *xmm_crc0 = x_tmp3;
+    *xmm_crc1 = _mm_castps_si128(ps_res10);
+    *xmm_crc2 = _mm_castps_si128(ps_res21);
+    *xmm_crc3 = _mm_castps_si128(ps_res32);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static void fold_4(__m128i * xmm_crc0, __m128i * xmm_crc1, __m128i * xmm_crc2, __m128i * xmm_crc3) {
+    const __m128i xmm_fold4 = _mm_set_epi32(0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596);
+    __m128i x_tmp0, x_tmp1, x_tmp2, x_tmp3;
+    __m128 ps_crc0, ps_crc1, ps_crc2, ps_crc3;
+    __m128 ps_t0, ps_t1, ps_t2, ps_t3;
+    __m128 ps_res0, ps_res1, ps_res2, ps_res3;
+
+    x_tmp0 = *xmm_crc0;
+    x_tmp1 = *xmm_crc1;
+    x_tmp2 = *xmm_crc2;
+    x_tmp3 = *xmm_crc3;
+
+    *xmm_crc0 = _mm_clmulepi64_si128(*xmm_crc0, xmm_fold4, 0x01);
+    x_tmp0 = _mm_clmulepi64_si128(x_tmp0, xmm_fold4, 0x10);
+    ps_crc0 = _mm_castsi128_ps(*xmm_crc0);
+    ps_t0 = _mm_castsi128_ps(x_tmp0);
+    ps_res0 = _mm_xor_ps(ps_crc0, ps_t0);
+
+    *xmm_crc1 = _mm_clmulepi64_si128(*xmm_crc1, xmm_fold4, 0x01);
+    x_tmp1 = _mm_clmulepi64_si128(x_tmp1, xmm_fold4, 0x10);
+    ps_crc1 = _mm_castsi128_ps(*xmm_crc1);
+    ps_t1 = _mm_castsi128_ps(x_tmp1);
+    ps_res1 = _mm_xor_ps(ps_crc1, ps_t1);
+
+    *xmm_crc2 = _mm_clmulepi64_si128(*xmm_crc2, xmm_fold4, 0x01);
+    x_tmp2 = _mm_clmulepi64_si128(x_tmp2, xmm_fold4, 0x10);
+    ps_crc2 = _mm_castsi128_ps(*xmm_crc2);
+    ps_t2 = _mm_castsi128_ps(x_tmp2);
+    ps_res2 = _mm_xor_ps(ps_crc2, ps_t2);
+
+    *xmm_crc3 = _mm_clmulepi64_si128(*xmm_crc3, xmm_fold4, 0x01);
+    x_tmp3 = _mm_clmulepi64_si128(x_tmp3, xmm_fold4, 0x10);
+    ps_crc3 = _mm_castsi128_ps(*xmm_crc3);
+    ps_t3 = _mm_castsi128_ps(x_tmp3);
+    ps_res3 = _mm_xor_ps(ps_crc3, ps_t3);
+
+    *xmm_crc0 = _mm_castps_si128(ps_res0);
+    *xmm_crc1 = _mm_castps_si128(ps_res1);
+    *xmm_crc2 = _mm_castps_si128(ps_res2);
+    *xmm_crc3 = _mm_castps_si128(ps_res3);
+}
+
+static const unsigned ALIGNED_(32) pshufb_shf_table[60] = {
+    0x84838281, 0x88878685, 0x8c8b8a89, 0x008f8e8d, /* shl 15 (16 - 1)/shr1 */
+    0x85848382, 0x89888786, 0x8d8c8b8a, 0x01008f8e, /* shl 14 (16 - 3)/shr2 */
+    0x86858483, 0x8a898887, 0x8e8d8c8b, 0x0201008f, /* shl 13 (16 - 4)/shr3 */
+    0x87868584, 0x8b8a8988, 0x8f8e8d8c, 0x03020100, /* shl 12 (16 - 4)/shr4 */
+    0x88878685, 0x8c8b8a89, 0x008f8e8d, 0x04030201, /* shl 11 (16 - 5)/shr5 */
+    0x89888786, 0x8d8c8b8a, 0x01008f8e, 0x05040302, /* shl 10 (16 - 6)/shr6 */
+    0x8a898887, 0x8e8d8c8b, 0x0201008f, 0x06050403, /* shl  9 (16 - 7)/shr7 */
+    0x8b8a8988, 0x8f8e8d8c, 0x03020100, 0x07060504, /* shl  8 (16 - 8)/shr8 */
+    0x8c8b8a89, 0x008f8e8d, 0x04030201, 0x08070605, /* shl  7 (16 - 9)/shr9 */
+    0x8d8c8b8a, 0x01008f8e, 0x05040302, 0x09080706, /* shl  6 (16 -10)/shr10*/
+    0x8e8d8c8b, 0x0201008f, 0x06050403, 0x0a090807, /* shl  5 (16 -11)/shr11*/
+    0x8f8e8d8c, 0x03020100, 0x07060504, 0x0b0a0908, /* shl  4 (16 -12)/shr12*/
+    0x008f8e8d, 0x04030201, 0x08070605, 0x0c0b0a09, /* shl  3 (16 -13)/shr13*/
+    0x01008f8e, 0x05040302, 0x09080706, 0x0d0c0b0a, /* shl  2 (16 -14)/shr14*/
+    0x0201008f, 0x06050403, 0x0a090807, 0x0e0d0c0b  /* shl  1 (16 -15)/shr15*/
+};
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static void partial_fold(const size_t len, __m128i * xmm_crc0, __m128i * xmm_crc1, __m128i * xmm_crc2,
+    __m128i * xmm_crc3, __m128i * xmm_crc_part) {
+    const __m128i xmm_fold4 = _mm_set_epi32(0x00000001, 0x54442bd4,
+        0x00000001, 0xc6e41596);
+    const __m128i xmm_mask3 = _mm_set1_epi32((int32_t)0x80808080);
+
+    __m128i xmm_shl, xmm_shr, xmm_tmp1, xmm_tmp2, xmm_tmp3;
+    __m128i xmm_a0_0, xmm_a0_1;
+    __m128 ps_crc3, psa0_0, psa0_1, ps_res;
+
+    xmm_shl = _mm_load_si128((__m128i*)(pshufb_shf_table + (4 * (len - 1))));
+    xmm_shr = xmm_shl;
+    xmm_shr = _mm_xor_si128(xmm_shr, xmm_mask3);
+
+    xmm_a0_0 = _mm_shuffle_epi8(*xmm_crc0, xmm_shl);
+
+    *xmm_crc0 = _mm_shuffle_epi8(*xmm_crc0, xmm_shr);
+    xmm_tmp1 = _mm_shuffle_epi8(*xmm_crc1, xmm_shl);
+    *xmm_crc0 = _mm_or_si128(*xmm_crc0, xmm_tmp1);
+
+    *xmm_crc1 = _mm_shuffle_epi8(*xmm_crc1, xmm_shr);
+    xmm_tmp2 = _mm_shuffle_epi8(*xmm_crc2, xmm_shl);
+    *xmm_crc1 = _mm_or_si128(*xmm_crc1, xmm_tmp2);
+
+    *xmm_crc2 = _mm_shuffle_epi8(*xmm_crc2, xmm_shr);
+    xmm_tmp3 = _mm_shuffle_epi8(*xmm_crc3, xmm_shl);
+    *xmm_crc2 = _mm_or_si128(*xmm_crc2, xmm_tmp3);
+
+    *xmm_crc3 = _mm_shuffle_epi8(*xmm_crc3, xmm_shr);
+    *xmm_crc_part = _mm_shuffle_epi8(*xmm_crc_part, xmm_shl);
+    *xmm_crc3 = _mm_or_si128(*xmm_crc3, *xmm_crc_part);
+
+    xmm_a0_1 = _mm_clmulepi64_si128(xmm_a0_0, xmm_fold4, 0x10);
+    xmm_a0_0 = _mm_clmulepi64_si128(xmm_a0_0, xmm_fold4, 0x01);
+
+    ps_crc3 = _mm_castsi128_ps(*xmm_crc3);
+    psa0_0 = _mm_castsi128_ps(xmm_a0_0);
+    psa0_1 = _mm_castsi128_ps(xmm_a0_1);
+
+    ps_res = _mm_xor_ps(ps_crc3, psa0_0);
+    ps_res = _mm_xor_ps(ps_res, psa0_1);
+
+    *xmm_crc3 = _mm_castps_si128(ps_res);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline void crc32_fold_load(__m128i * fold, __m128i * fold0, __m128i * fold1, __m128i * fold2, __m128i * fold3) {
+    *fold0 = _mm_load_si128(fold + 0);
+    *fold1 = _mm_load_si128(fold + 1);
+    *fold2 = _mm_load_si128(fold + 2);
+    *fold3 = _mm_load_si128(fold + 3);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline void crc32_fold_save(__m128i * fold, const __m128i * fold0, const __m128i * fold1,
+    const __m128i * fold2, const __m128i * fold3) {
+    _mm_storeu_si128(fold + 0, *fold0);
+    _mm_storeu_si128(fold + 1, *fold1);
+    _mm_storeu_si128(fold + 2, *fold2);
+    _mm_storeu_si128(fold + 3, *fold3);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline  uint32_t CRC32_FOLD_RESET(crc32_fold * crc) {
+    __m128i xmm_crc0 = _mm_cvtsi32_si128(0x9db42487);
+    __m128i xmm_zero = _mm_setzero_si128();
+    crc32_fold_save((__m128i*)crc->fold, &xmm_crc0, &xmm_zero, &xmm_zero, &xmm_zero);
+    return 0;
+}
+
+static const unsigned ALIGNED_(16) crc_k[] = {
+    0xccaa009e, 0x00000000, /* rk1 */
+    0x751997d0, 0x00000001, /* rk2 */
+    0xccaa009e, 0x00000000, /* rk5 */
+    0x63cd6124, 0x00000001, /* rk6 */
+    0xf7011640, 0x00000001, /* rk7 */
+    0xdb710640, 0x00000001  /* rk8 */
+};
+
+static const unsigned ALIGNED_(16) crc_mask[4] = {
+    0xFFFFFFFF, 0xFFFFFFFF, 0x00000000, 0x00000000
+};
+
+static const unsigned ALIGNED_(16) crc_mask2[4] = {
+    0x00000000, 0xFFFFFFFF, 0xFFFFFFFF, 0xFFFFFFFF
+};
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline uint32_t CRC32_FOLD_FINAL(crc32_fold * crc) {
+    const __m128i xmm_mask = _mm_load_si128((__m128i*)crc_mask);
+    const __m128i xmm_mask2 = _mm_load_si128((__m128i*)crc_mask2);
+    __m128i xmm_crc0, xmm_crc1, xmm_crc2, xmm_crc3;
+    __m128i x_tmp0, x_tmp1, x_tmp2, crc_fold;
+
+    crc32_fold_load((__m128i*)crc->fold, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+
+    /*
+     * k1
+     */
+    crc_fold = _mm_load_si128((__m128i*)crc_k);
+
+    x_tmp0 = _mm_clmulepi64_si128(xmm_crc0, crc_fold, 0x10);
+    xmm_crc0 = _mm_clmulepi64_si128(xmm_crc0, crc_fold, 0x01);
+    xmm_crc1 = _mm_xor_si128(xmm_crc1, x_tmp0);
+    xmm_crc1 = _mm_xor_si128(xmm_crc1, xmm_crc0);
+
+    x_tmp1 = _mm_clmulepi64_si128(xmm_crc1, crc_fold, 0x10);
+    xmm_crc1 = _mm_clmulepi64_si128(xmm_crc1, crc_fold, 0x01);
+    xmm_crc2 = _mm_xor_si128(xmm_crc2, x_tmp1);
+    xmm_crc2 = _mm_xor_si128(xmm_crc2, xmm_crc1);
+
+    x_tmp2 = _mm_clmulepi64_si128(xmm_crc2, crc_fold, 0x10);
+    xmm_crc2 = _mm_clmulepi64_si128(xmm_crc2, crc_fold, 0x01);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, x_tmp2);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc2);
+
+    /*
+     * k5
+     */
+    crc_fold = _mm_load_si128((__m128i*)(crc_k + 4));
+
+    xmm_crc0 = xmm_crc3;
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0);
+    xmm_crc0 = _mm_srli_si128(xmm_crc0, 8);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc0);
+
+    xmm_crc0 = xmm_crc3;
+    xmm_crc3 = _mm_slli_si128(xmm_crc3, 4);
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0x10);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc0);
+    xmm_crc3 = _mm_and_si128(xmm_crc3, xmm_mask2);
+
+    /*
+     * k7
+     */
+    xmm_crc1 = xmm_crc3;
+    xmm_crc2 = xmm_crc3;
+    crc_fold = _mm_load_si128((__m128i*)(crc_k + 8));
+
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc2);
+    xmm_crc3 = _mm_and_si128(xmm_crc3, xmm_mask);
+
+    xmm_crc2 = xmm_crc3;
+    xmm_crc3 = _mm_clmulepi64_si128(xmm_crc3, crc_fold, 0x10);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc2);
+    xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_crc1);
+
+    crc->value = ~((uint32_t)_mm_extract_epi32(xmm_crc3, 2));
+
+    return crc->value;
+}
+
+static inline uint32_t crc32_small(uint32_t crc, const uint8_t * buf, size_t len) {
+    uint32_t c = (~crc) & 0xffffffff;
+
+    while (len) {
+        len--;
+        DO1;
+    }
+
+    return c ^ 0xffffffff;
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline void CRC32_FOLD(crc32_fold * crc, const uint8_t * src, size_t len, uint32_t init_crc) {
+    unsigned long algn_diff;
+    __m128i xmm_t0, xmm_t1, xmm_t2, xmm_t3;
+    __m128i xmm_crc0, xmm_crc1, xmm_crc2, xmm_crc3;
+    __m128i xmm_crc_part = _mm_setzero_si128();
+    char ALIGNED_(16) partial_buf[16] = { 0 };
+    __m128i xmm_initial = _mm_cvtsi32_si128(init_crc);
+    int32_t first = init_crc != 0;
+
+    /* The CRC functions don't call this for input < 16, as a minimum of 16 bytes of input is needed
+     * for the aligning load that occurs.  If there's an initial CRC, to carry it forward through
+     * the folded CRC there must be 16 - src % 16 + 16 bytes available, which by definition can be
+     * up to 15 bytes + one full vector load. */
+    Assert(len >= 16 || first == 0, "Invalid len or init_crc values.");
+
+    crc32_fold_load((__m128i*)crc->fold, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+
+    if (len < 16) {
+        if (len == 0)
+            return;
+
+        memcpy(partial_buf, src, len);
+        xmm_crc_part = _mm_load_si128((const __m128i*)partial_buf);
+        goto partial;
+    }
+
+    algn_diff = ((uintptr_t)16 - ((uintptr_t)src & 0xF)) & 0xF;
+    if (algn_diff) {
+        xmm_crc_part = _mm_loadu_si128((__m128i*)src);
+        XOR_INITIAL128(xmm_crc_part);
+
+        if (algn_diff < 4 && init_crc != 0) {
+            xmm_t0 = xmm_crc_part;
+            if (len >= 32) {
+                xmm_crc_part = _mm_loadu_si128((__m128i*)src + 1);
+                fold_1(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+                xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t0);
+            }
+            else {
+                memcpy(partial_buf, src + 16, len - 16);
+                xmm_crc_part = _mm_load_si128((__m128i*)partial_buf);
+                fold_1(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+                xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t0);
+                src += 16;
+                len -= 16;
+                goto partial;
+            }
+
+            src += 16;
+            len -= 16;
+        }
+
+        partial_fold(algn_diff, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
+
+        src += algn_diff;
+        len -= algn_diff;
+    }
+
+#ifdef X86_VPCLMULQDQ
+    if (len >= 256) {
+        size_t n = fold_16_vpclmulqdq(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, src, len,
+            xmm_initial, first);
+        first = 0;
+        len -= n;
+        src += n;
+    }
+#endif
+
+    while (len >= 64) {
+        len -= 64;
+        xmm_t0 = _mm_load_si128((__m128i*)src);
+        xmm_t1 = _mm_load_si128((__m128i*)src + 1);
+        xmm_t2 = _mm_load_si128((__m128i*)src + 2);
+        xmm_t3 = _mm_load_si128((__m128i*)src + 3);
+        src += 64;
+
+        fold_4(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+        XOR_INITIAL128(xmm_t0);
+
+        xmm_crc0 = _mm_xor_si128(xmm_crc0, xmm_t0);
+        xmm_crc1 = _mm_xor_si128(xmm_crc1, xmm_t1);
+        xmm_crc2 = _mm_xor_si128(xmm_crc2, xmm_t2);
+        xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t3);
+    }
+
+    /*
+     * len = num bytes left - 64
+     */
+    if (len >= 48) {
+        len -= 48;
+
+        xmm_t0 = _mm_load_si128((__m128i*)src);
+        xmm_t1 = _mm_load_si128((__m128i*)src + 1);
+        xmm_t2 = _mm_load_si128((__m128i*)src + 2);
+        src += 48;
+        XOR_INITIAL128(xmm_t0);
+        fold_3(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+
+        xmm_crc1 = _mm_xor_si128(xmm_crc1, xmm_t0);
+        xmm_crc2 = _mm_xor_si128(xmm_crc2, xmm_t1);
+        xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t2);
+    }
+    else if (len >= 32) {
+        len -= 32;
+
+        xmm_t0 = _mm_load_si128((__m128i*)src);
+        xmm_t1 = _mm_load_si128((__m128i*)src + 1);
+        src += 32;
+        XOR_INITIAL128(xmm_t0);
+        fold_2(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+
+        xmm_crc2 = _mm_xor_si128(xmm_crc2, xmm_t0);
+        xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t1);
+    }
+    else if (len >= 16) {
+        len -= 16;
+        xmm_t0 = _mm_load_si128((__m128i*)src);
+        src += 16;
+        XOR_INITIAL128(xmm_t0);
+        fold_1(&xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+
+        xmm_crc3 = _mm_xor_si128(xmm_crc3, xmm_t0);
+    }
+
+partial:
+    if (len) {
+        memcpy(&xmm_crc_part, src, len);
+        partial_fold(len, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3, &xmm_crc_part);
+    }
+
+    crc32_fold_save((__m128i*)crc->fold, &xmm_crc0, &xmm_crc1, &xmm_crc2, &xmm_crc3);
+}
+
+__attribute__((__target__(CRC_32_Z_TARGET_ISA)))
+static inline uint32_t CRC_32_Z_X86(uint32_t crc32, const uint8_t* buf, size_t len) {
+    /* For lens smaller than ~12, crc32_small method is faster.
+     * But there are also minimum requirements for the pclmul functions due to alignment */
+    if (len < 16)
+        return crc32_small(crc32, buf, len);
+
+    crc32_fold ALIGNED_(16) crc_state;
+    CRC32_FOLD_RESET(&crc_state);
+    CRC32_FOLD(&crc_state, buf, len, crc32);
+    return CRC32_FOLD_FINAL(&crc_state);
+}
+
+#undef CRC_32_Z_TARGET_ISA
+#undef CRC_32_Z_VARIANT
+#endif /* CRC_32_Z_VARIANT */
+
+#endif /*_CRC32_X86_ */

--- a/extra/zlib/zlib-1.2.13/crc32_x86_pclmul.c
+++ b/extra/zlib/zlib-1.2.13/crc32_x86_pclmul.c
@@ -1,0 +1,38 @@
+/**
+ * Copyright (C) 2022-2025, Advanced Micro Devices. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+#include "arch_x86.h"
+
+#ifdef ZLIB_X86_64_CRC32_PCLMUL
+#define CRC_32_Z_X86_PCLMUL 1
+
+#define CRC_32_Z_VARIANT CRC_32_Z_X86_PCLMUL
+#include "crc32_x86.h"
+#else
+// A dummy declaration to avoid "error: ISO C forbids an empty translation unit [-Werror=pedantic]"
+void dummy_function_crc32_x86_pclmul(void) {}
+#endif /* ZLIB_X86_64_CRC32_PCLMUL */

--- a/extra/zlib/zlib-1.2.13/crc32_x86_vpclmulqdq.c
+++ b/extra/zlib/zlib-1.2.13/crc32_x86_vpclmulqdq.c
@@ -1,0 +1,43 @@
+/**
+ * Copyright (C) 2022-2025, Advanced Micro Devices. All rights reserved.
+ * 
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ * this list of conditions and the following disclaimer in the documentation
+ * and/or other materials provided with the distribution.
+ * 3. Neither the name of the copyright holder nor the names of its
+ * contributors may be used to endorse or promote products derived from this
+ * software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "arch_x86.h"
+#ifdef ZLIB_X86_64_CRC32_PCLMUL
+
+#ifdef HAVE_VPCLMULQDQ_ATTRIBUTE
+
+#define CRC_32_Z_X86_VPCLMULQDQ 2
+
+#define CRC_32_Z_VARIANT CRC_32_Z_X86_VPCLMULQDQ
+#include "crc32_x86.h"
+#else
+// A dummy declaration to avoid "error: ISO C forbids an empty translation unit [-Werror=pedantic]"
+void dummy_function_crc32_x86_vpclmulqdq(void) {}
+
+#endif /* HAVE_VPCLMULQDQ_ATTRIBUTE */
+#endif /* ZLIB_X86_64_CRC32_PCLMUL */

--- a/unittest/gunit/mysys_my_checksum-t.cc
+++ b/unittest/gunit/mysys_my_checksum-t.cc
@@ -21,6 +21,8 @@
    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
 
 #include <algorithm>
+#include <array>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -33,6 +35,21 @@
 using namespace mycrc32;
 
 namespace mysys_my_checksum {
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+extern "C" {
+int has_crc32_x86_avx(void);
+int has_crc32_x86_avx512(void);
+unsigned long crc32_z_impl_x86_avx(unsigned long crc,
+                                   const unsigned char FAR *buf, z_size_t len);
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+unsigned long crc32_z_impl_x86_avx512(unsigned long crc,
+                                      const unsigned char FAR *buf, z_size_t len)
+    __attribute__((weak));
+#endif
+}
+#endif
+
 std::uint32_t VerifyChecksumFuncs(const unsigned char *buf,
                                   std::size_t length) {
   std::uint32_t crc_seed = 0xbadcafe;
@@ -42,6 +59,34 @@ std::uint32_t VerifyChecksumFuncs(const unsigned char *buf,
   EXPECT_EQ(expected_crc, PunnedCrc32<std::uint64_t>(crc_seed, buf, length));
   return expected_crc;
 }
+
+std::uint32_t TableCrc32Reference(std::uint32_t crc_seed,
+                                  const unsigned char *buf,
+                                  std::size_t length) {
+  const z_crc_t FAR *table = get_crc_table();
+  std::uint32_t crc = (~crc_seed) & 0xffffffffU;
+  for (std::size_t i = 0; i < length; ++i) {
+    crc = (crc >> 8) ^ static_cast<std::uint32_t>(table[(crc ^ buf[i]) & 0xffU]);
+  }
+  return crc ^ 0xffffffffU;
+}
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+void VerifyAgainstTableAndZlib(
+    const std::vector<unsigned char> &data, std::size_t offset, std::size_t len,
+    std::uint32_t seed,
+    unsigned long (*impl)(unsigned long, const unsigned char FAR *, z_size_t)) {
+  const unsigned char *ptr = data.data() + offset;
+  const std::uint32_t table_crc = TableCrc32Reference(seed, ptr, len);
+  const std::uint32_t z_crc = crc32_z(seed, ptr, len);
+  const std::uint32_t simd_crc = impl(seed, ptr, len);
+
+  EXPECT_EQ(table_crc, z_crc)
+      << "offset=" << offset << " seed=" << seed << " len=" << len;
+  EXPECT_EQ(table_crc, simd_crc)
+      << "offset=" << offset << " seed=" << seed << " len=" << len;
+}
+#endif
 
 TEST(MysysMyChecksum, EmptyBuffer) {
   unsigned char b[1] = {'0'};
@@ -120,6 +165,176 @@ TEST(MysysMyChecksum, IntegerCrc32_64bit) {
   std::uint32_t zres = crc32_z(~crc, value_bytes, sizeof(value_bytes));
   EXPECT_EQ(IntegerCrc32(crc, value), ~zres);
 }
+
+#if defined(__x86_64__) || defined(__amd64__) || defined(_M_X64)
+TEST(MysysMyChecksum, Crc32ZMatchesAvxImplementationWhenSupported) {
+  if (!has_crc32_x86_avx()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX+PCLMUL CRC32";
+  }
+
+  std::vector<unsigned char> data(8192 + 257);
+  unsigned char v = 0x5a;
+  std::generate(data.begin(), data.end(), [&] { return ++v; });
+
+  const std::array<std::size_t, 22> lengths = {
+      0,    1,    2,    3,    7,    8,    9,    15,   16,   31,   32,
+      63,   64,   65,   127,  128,  255,  256,  511,  4096, 7777, 8192};
+  const std::array<std::uint32_t, 4> seeds = {0u, 1u, 0xbadcafeu, 0xdeadcafeu};
+  const std::array<std::size_t, 4> offsets = {0, 1, 3, 7};
+
+  for (std::uint32_t seed : seeds) {
+    for (std::size_t offset : offsets) {
+      for (std::size_t len : lengths) {
+        VerifyAgainstTableAndZlib(data, offset, len, seed, crc32_z_impl_x86_avx);
+      }
+    }
+  }
+}
+
+TEST(MysysMyChecksum, Crc32ZDispatchesToAvxImplementationWhenSupported) {
+  if (!has_crc32_x86_avx()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX+PCLMUL CRC32";
+  }
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+  if (crc32_z_impl_x86_avx512 != nullptr && has_crc32_x86_avx512()) {
+    GTEST_SKIP() << "crc32_z uses AVX512 path on this CPU";
+  }
+#endif
+
+  alignas(alignof(std::uint64_t)) unsigned char buf[256];
+  unsigned char v = 0x3c;
+  std::generate(buf, buf + sizeof(buf), [&] { return v += 0x11; });
+
+  const std::array<std::size_t, 6> lengths = {0, 16, 64, 127, 255, 256};
+  const std::array<std::uint32_t, 3> seeds = {0u, 0xbadcafeu, 0xffffffffu};
+  const std::array<std::size_t, 3> offsets = {0, 3, 7};
+
+  for (std::uint32_t seed : seeds) {
+    for (std::size_t offset : offsets) {
+      for (std::size_t len : lengths) {
+        const unsigned char *ptr = buf + offset;
+        const std::uint32_t z_crc = crc32_z(seed, ptr, len);
+        const std::uint32_t avx_crc =
+            crc32_z_impl_x86_avx(seed, ptr, len);
+        EXPECT_EQ(avx_crc, z_crc)
+            << "offset=" << offset << " seed=" << seed << " len=" << len;
+      }
+    }
+  }
+}
+
+TEST(MysysMyChecksum, ShortLengthWithNonZeroSeedMatchesReference) {
+  if (!has_crc32_x86_avx()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX+PCLMUL CRC32";
+  }
+
+  std::vector<unsigned char> data(32);
+  unsigned char v = 0xa0;
+  std::generate(data.begin(), data.end(), [&] { return ++v; });
+
+  const std::array<std::size_t, 4> lengths = {12, 13, 14, 15};
+  const std::uint32_t seed = 0xbadcafeu;
+  const std::array<std::size_t, 4> offsets = {0, 1, 3, 7};
+
+  for (std::size_t offset : offsets) {
+    for (std::size_t len : lengths) {
+      const unsigned char *ptr = data.data() + offset;
+      VerifyAgainstTableAndZlib(data, offset, len, seed,
+                                crc32_z_impl_x86_avx);
+      EXPECT_EQ(crc32_z(seed, ptr, len),
+                crc32_z_impl_x86_avx(seed, ptr, len))
+          << "offset=" << offset << " len=" << len;
+    }
+  }
+}
+
+TEST(MysysMyChecksum, SixteenByteBoundaryWithVariousOffsets) {
+  if (!has_crc32_x86_avx()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX+PCLMUL CRC32";
+  }
+
+  std::vector<unsigned char> data(48);
+  unsigned char v = 0x11;
+  std::generate(data.begin(), data.end(), [&] { return v += 7; });
+
+  constexpr std::size_t len = 16;
+  const std::array<std::uint32_t, 3> seeds = {0u, 0xbadcafeu, 0xffffffffu};
+  const std::array<std::size_t, 5> offsets = {0, 1, 5, 11, 15};
+
+  for (std::uint32_t seed : seeds) {
+    for (std::size_t offset : offsets) {
+      VerifyAgainstTableAndZlib(data, offset, len, seed,
+                                crc32_z_impl_x86_avx);
+      const unsigned char *ptr = data.data() + offset;
+      EXPECT_EQ(crc32_z(seed, ptr, len),
+                crc32_z_impl_x86_avx(seed, ptr, len))
+          << "offset=" << offset << " seed=" << seed;
+    }
+  }
+}
+
+#if defined(__GNUC__) && (__GNUC__ >= 8)
+TEST(MysysMyChecksum, Crc32ZDispatchesToAvx512ImplementationWhenSupported) {
+  if (crc32_z_impl_x86_avx512 == nullptr) {
+    GTEST_SKIP() << "AVX512 crc32 implementation is not linked in this build";
+  }
+  if (!has_crc32_x86_avx512()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX-512 VPCLMUL CRC32";
+  }
+
+  std::vector<unsigned char> data(4096 + 16);
+  unsigned char v = 0x7e;
+  std::generate(data.begin(), data.end(), [&] { return v += 0x09; });
+
+  const std::array<std::size_t, 6> lengths = {0, 16, 256, 512, 1024, 4096};
+  const std::array<std::uint32_t, 3> seeds = {0u, 0x10203040u, 0xffffffffu};
+  const std::array<std::size_t, 3> offsets = {0, 5, 11};
+
+  for (std::uint32_t seed : seeds) {
+    for (std::size_t offset : offsets) {
+      for (std::size_t len : lengths) {
+        if (offset + len > data.size()) continue;
+        const unsigned char *ptr = data.data() + offset;
+        const std::uint32_t z_crc = crc32_z(seed, ptr, len);
+        const std::uint32_t avx512_crc =
+            crc32_z_impl_x86_avx512(seed, ptr, len);
+        EXPECT_EQ(avx512_crc, z_crc)
+            << "offset=" << offset << " seed=" << seed << " len=" << len;
+      }
+    }
+  }
+}
+
+TEST(MysysMyChecksum, Crc32ZMatchesAvx512ImplementationWhenSupported) {
+  if (crc32_z_impl_x86_avx512 == nullptr) {
+    GTEST_SKIP() << "AVX512 crc32 implementation is not linked in this build";
+  }
+  if (!has_crc32_x86_avx512()) {
+    GTEST_SKIP() << "CPU/OS does not support AVX-512 VPCLMUL CRC32";
+  }
+
+  std::vector<unsigned char> data(16384 + 129);
+  unsigned char v = 0xa5;
+  std::generate(data.begin(), data.end(), [&] { return v += 17; });
+
+  const std::array<std::size_t, 23> lengths = {
+      0,    1,     2,    3,    7,    8,    9,    15,   16,   31,   32,  63,
+      64,   65,    127,  128,  255,  256,  511,  512,  4095, 8192, 16384};
+  const std::array<std::uint32_t, 4> seeds = {0u, 0x10203040u, 0xbadcafeu,
+                                              0xffffffffu};
+  const std::array<std::size_t, 4> offsets = {0, 1, 5, 11};
+
+  for (std::uint32_t seed : seeds) {
+    for (std::size_t offset : offsets) {
+      for (std::size_t len : lengths) {
+        VerifyAgainstTableAndZlib(data, offset, len, seed,
+                                  crc32_z_impl_x86_avx512);
+      }
+    }
+  }
+}
+#endif
+#endif
 
 static volatile std::uint32_t do_not_optimize = 0;
 // 50k buffer, 8-byte using crc32_z directly


### PR DESCRIPTION
Add PCLMULQDQ and VPCLMULQDQ based CRC32 SIMD implementations for extra/zlib 1.2.13 on x86_64 platform, providing significant speedup over the default table-based computation.

- Add arch_x86.c/h for CPU feature detection (AVX, AVX512/VL)
- Add crc32_x86.h with SIMD CRC32 kernels using PCLMULQDQ
- Add crc32_x86_pclmul.c for AVX (128-bit) PCLMULQDQ path
- Add crc32_x86_vpclmulqdq.c for AVX512/VL VPCLMULQDQ path
- Modify crc32.c to dispatch to SIMD implementations at runtime
- Update CMakeLists.txt to include new x86_64 source files
- Add unit tests verifying SIMD CRC32 matches table-based reference